### PR TITLE
Fix bugs balance per month

### DIFF
--- a/src/main/resources/static/views/advertiserBalance.html
+++ b/src/main/resources/static/views/advertiserBalance.html
@@ -107,7 +107,7 @@
                                         ng-click="onApplyBtnClick();">
                                     Apply
                                 </button>
-                                <button class="btn btn-primary btn-md btn-fill btn-in-header btn-sm"
+                                <button class="btn btn-facebook btn-md btn-fill btn-in-header btn-sm"
                                         ng-click="go('/balancePerMonth')">
                                     Per month
                                 </button>
@@ -135,7 +135,7 @@
                                                type="text" ng-model="dt"
                                                options="dpOptions"
                                                placeholder="Click to choose date..."
-                                               style="width: 110%; margin-bottom: 8%;"/>
+                                               style="width: 110%;"/>
                                     </div>
                                 </form>
                             </div>

--- a/src/main/resources/static/views/balancePerMonth.html
+++ b/src/main/resources/static/views/balancePerMonth.html
@@ -106,53 +106,47 @@
                                     ng-click="go('/advertiserBalance')">
                                     Total
                                 </button>
-                                <button class="btn btn-primary btn-md btn-fill btn-sm btn-in-header"
+                                <button class="btn btn-facebook btn-md btn-fill btn-sm btn-in-header"
                                         data-toggle="modal"
                                         data-target="#addIncomeModal"
                                         ng-click="getAccounts();">
                                     Add
                                 </button>
-                                <button class="btn btn-primary btn-md btn-fill btn-sm btn-in-header"
+                                <button class="btn btn-facebook btn-md btn-fill btn-sm btn-in-header"
                                         data-toggle="modal"
                                         data-target="#moreInfoModal">
                                     More
                                 </button>
                             </div>
-                            <h4 class="card-title">Balance per month</h4>
+                            <form class="form-inline" style="margin-left: 10px;margin-top: 10px;">
+                                <div class="form-group">
+                                    <select class="selectpicker" multiple
+                                            data-style="btn-info btn-fill btn-block"
+                                            data-size="5"
+                                            title="Advertisers"
+                                            data-header="Advertisers"
+                                            ng-model="selectedAdv"
+                                            style="width: 130%;">
+                                        <option class="small-font" ng-repeat="a in advNames" data-select-watcher
+                                                data-last="{{$last}}" value="{{a.id}}">{{a.name}}
+                                        </option>
+                                    </select>
+                                </div>
+                                <div class="form-group">
+                                    <select class="form-control white-input-no-border"
+                                            data-ng-model="selectedYear"
+                                            data-ng-options="v as k for (k, v) in yearOptions">
+                                    </select>
+                                </div>
+                                <div class="form-group">
+                                    <select class="form-control white-input-no-border"
+                                            data-ng-model="selectedMonth"
+                                            data-ng-options="v as k for (k, v) in monthOptions">
+                                    </select>
+                                </div>
+                            </form>
                         </div>
                         <div class="card-content">
-                            <div class="row">
-                                <form class="form-inline" style="margin-left: 10px;margin-top: 10px;">
-                                    <div class="form-group"
-                                         style="margin-right:-3px;margin-bottom: 3px; margin-left: 5px;">
-                                        <select class="selectpicker" multiple
-                                                data-style="btn-info btn-fill btn-block"
-                                                data-size="5"
-                                                title="Advertisers"
-                                                data-header="Advertisers"
-                                                ng-model="selectedAdv"
-                                                style="width: 130%;margin-left: 5px;">
-                                            <option class="small-font" ng-repeat="a in advNames" data-select-watcher
-                                                    data-last="{{$last}}" value="{{a.id}}">{{a.name}}
-                                            </option>
-                                        </select>
-                                    </div>
-                                    <div class="form-group">
-                                        <select class="form-control white-input-no-border"
-                                                data-ng-model="selectedYear"
-                                                data-ng-options="v as k for (k, v) in yearOptions"
-                                                style="margin-bottom: 14px;">
-                                        </select>
-                                    </div>
-                                    <div class="form-group">
-                                        <select class="form-control white-input-no-border"
-                                                data-ng-model="selectedMonth"
-                                                data-ng-options="v as k for (k, v) in monthOptions"
-                                                style="margin-bottom: 14px;">
-                                        </select>
-                                    </div>
-                                </form>
-                            </div>
                             <div class="card-content table-responsive table-full-width">
                                 <table class="table">
                                     <thead>

--- a/src/main/resources/static/views/balancePerMonth.html
+++ b/src/main/resources/static/views/balancePerMonth.html
@@ -118,7 +118,7 @@
                                     More
                                 </button>
                             </div>
-                            <form class="form-inline" style="margin-left: 10px;margin-top: 10px;">
+                            <form class="form-inline">
                                 <div class="form-group">
                                     <select class="selectpicker" multiple
                                             data-style="btn-info btn-fill btn-block"


### PR DESCRIPTION
fix balance per month and balance by advert pages(mainly filters)


![image](https://user-images.githubusercontent.com/25778106/35534651-d9724cac-0549-11e8-99d6-1222b3a05498.png)
випадне меню Advertiser, year, month перенеси вище, замість заголовку Balance per month(це взагалі видали), подивись чому немає даних, з API все приходить і чи є API(я не памятаю щоб робив його)

і ще одне зауваження по дизайнові
треба притримуватись одного стилю для кнопок однакового призначення


API Немає, з кнопками пропоную зробити зелені для Apply(як зараз), primary(коричневі) для Cancel(як зараз), а для всіх інших типу Per Month, More .........  зробити btn-facebook, подивишся я їх додав на цих двох сторінках(balace per month, balance by adv), вони синьо-фіолетові, гарно виглядають, вписуються в дизайн мені здається